### PR TITLE
fix deprecation messages

### DIFF
--- a/R/analysis_mobile_server.R
+++ b/R/analysis_mobile_server.R
@@ -266,7 +266,6 @@ analysis_mobile_server <- function(input, output, session){
     output$threshPlots <- renderUI({
       tagList(
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           h3('Background Correction', align = "center"),

--- a/R/analysis_mobile_ui.R
+++ b/R/analysis_mobile_ui.R
@@ -16,7 +16,6 @@ analysis_mobile_ui <- f7Page(
         active = TRUE,
         # Upload file block
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "upload", label="Upload image or choose sample", choices=list("Upload image", "Sample"), selected = "Sample"),
@@ -52,7 +51,6 @@ analysis_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Set number of strips and number of lines per strip"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           f7Slider("strips", label="Number of strips", min=1, max=10, value=1, scale=TRUE, scaleSteps=9),
@@ -60,7 +58,6 @@ analysis_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Cropping and Segmentation", size="medium"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           # The content of the tab goes below this
@@ -147,7 +144,6 @@ analysis_mobile_ui <- f7Page(
         icon = f7Icon("circle_lefthalf_fill"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           "Select strip: ",
@@ -193,7 +189,6 @@ analysis_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload existing intensity data",
               f7File(inputId = 'intensFile',
@@ -224,7 +219,6 @@ analysis_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload experiment info or upload existing merged data",
               f7Accordion(
@@ -283,7 +277,6 @@ analysis_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse=TRUE,
             f7AccordionItem(
               title = "Upload existing data for calibration",
               f7File(inputId = 'prepFile',
@@ -385,7 +378,6 @@ analysis_mobile_ui <- f7Page(
         icon = f7Icon("gauge"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "quanUpload",

--- a/R/cal_mobile_server.R
+++ b/R/cal_mobile_server.R
@@ -264,7 +264,6 @@ cal_mobile_server <- function(input, output, session){
     output$threshPlots <- renderUI({
       tagList(
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           h3('Background Correction', align = "center"),

--- a/R/cal_mobile_ui.R
+++ b/R/cal_mobile_ui.R
@@ -16,7 +16,6 @@ cal_mobile_ui <- f7Page(
         active = TRUE,
         # Upload file block
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "upload", label="Upload image or choose sample", choices=list("Upload image", "Sample"), selected = "Sample"),
@@ -52,7 +51,6 @@ cal_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Set number of strips and number of lines per strip"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           f7Slider("strips", label="Number of strips", min=1, max=10, value=1, scale=TRUE, scaleSteps=9),
@@ -60,7 +58,6 @@ cal_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Cropping and Segmentation", size="medium"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           # The content of the tab goes below this
@@ -147,7 +144,6 @@ cal_mobile_ui <- f7Page(
         icon = f7Icon("circle_lefthalf_fill"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           "Select strip: ",
@@ -193,7 +189,6 @@ cal_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload existing intensity data",
               f7File(inputId = 'intensFile',
@@ -224,7 +219,6 @@ cal_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload experiment info or upload existing merged data",
               f7Accordion(
@@ -283,7 +277,6 @@ cal_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse=TRUE,
             f7AccordionItem(
               title = "Upload existing data for calibration",
               f7File(inputId = 'prepFile',

--- a/R/core_mobile_server.R
+++ b/R/core_mobile_server.R
@@ -253,7 +253,6 @@ core_mobile_server <- function(input, output, session){
     output$threshPlots <- renderUI({
       tagList(
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           h3('Background Correction', align = "center"),

--- a/R/core_mobile_ui.R
+++ b/R/core_mobile_ui.R
@@ -16,7 +16,6 @@ core_mobile_ui <- f7Page(
         active = TRUE,
         # Upload file block
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "upload", label="Upload image or choose sample", choices=list("Upload image", "Sample"), selected = "Sample"),
@@ -52,7 +51,6 @@ core_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Set number of strips and number of lines per strip"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           f7Slider("strips", label="Number of strips", min=1, max=10, value=1, scale=TRUE, scaleSteps=9),
@@ -60,7 +58,6 @@ core_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Cropping and Segmentation", size="medium"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           # The content of the tab goes below this
@@ -79,7 +76,6 @@ core_mobile_ui <- f7Page(
         icon = f7Icon("circle_lefthalf_fill"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           "Select strip: ",
@@ -125,7 +121,6 @@ core_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload existing intensity data",
               f7File(inputId = 'intensFile',

--- a/R/quan_mobile_server.R
+++ b/R/quan_mobile_server.R
@@ -256,7 +256,6 @@ quan_mobile_server <- function(input, output, session){
     output$threshPlots <- renderUI({
       tagList(
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           h3('Background Correction', align = "center"),

--- a/R/quan_mobile_ui.R
+++ b/R/quan_mobile_ui.R
@@ -16,7 +16,6 @@ quan_mobile_ui <- f7Page(
         active = TRUE,
         # Upload file block
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "upload", label="Upload image or choose sample", choices=list("Upload image", "Sample"), selected = "Sample"),
@@ -52,7 +51,6 @@ quan_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Set number of strips and number of lines per strip"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           f7Slider("strips", label="Number of strips", min=1, max=10, value=1, scale=TRUE, scaleSteps=9),
@@ -60,7 +58,6 @@ quan_mobile_ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Cropping and Segmentation", size="medium"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           # The content of the tab goes below this
@@ -80,7 +77,6 @@ quan_mobile_ui <- f7Page(
         icon = f7Icon("circle_lefthalf_fill"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           "Select strip: ",
@@ -127,7 +123,6 @@ quan_mobile_ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload existing intensity data",
               f7File(inputId = 'intensFile',
@@ -157,7 +152,6 @@ quan_mobile_ui <- f7Page(
         icon = f7Icon("gauge"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "quanUpload",

--- a/shinyapps.io/LFApp Mobile Analysis/app.R
+++ b/shinyapps.io/LFApp Mobile Analysis/app.R
@@ -23,7 +23,6 @@ ui <- f7Page(
         active = TRUE,
         # Upload file block
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "upload", label="Upload image or choose sample", choices=list("Upload image", "Sample"), selected = "Sample"),
@@ -59,7 +58,6 @@ ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Set number of strips and number of lines per strip"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           f7Slider("strips", label="Number of strips", min=1, max=10, value=1, scale=TRUE, scaleSteps=9),
@@ -67,7 +65,6 @@ ui <- f7Page(
         ),
         f7Block(
           f7BlockTitle("Cropping and Segmentation", size="medium"),
-          hairlines = TRUE,
           strong = TRUE,
           inset = FALSE,
           # The content of the tab goes below this
@@ -154,7 +151,6 @@ ui <- f7Page(
         icon = f7Icon("circle_lefthalf_fill"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           "Select strip: ",
@@ -200,7 +196,6 @@ ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload existing intensity data",
               f7File(inputId = 'intensFile',
@@ -231,7 +226,6 @@ ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse = TRUE,
             f7AccordionItem(
               title = "Upload experiment info or upload existing merged data",
               f7Accordion(
@@ -290,7 +284,6 @@ ui <- f7Page(
         active = FALSE,
         f7Block(
           f7Accordion(
-            multiCollapse=TRUE,
             f7AccordionItem(
               title = "Upload existing data for calibration",
               f7File(inputId = 'prepFile',
@@ -386,7 +379,6 @@ ui <- f7Page(
         icon = f7Icon("gauge"),
         active = FALSE,
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           f7Radio(inputId= "quanUpload",
@@ -794,7 +786,6 @@ server <- function(input, output, session){
     output$threshPlots <- renderUI({
       tagList(
         f7Block(
-          hairlines = FALSE,
           strong = TRUE,
           inset = FALSE,
           h3('Background Correction', align = "center"),


### PR DESCRIPTION
Currently `{shinyMobile}` 2.0.0 is triggering some deprecation messages in your app. This PR fixes those messages.

```shell
*   checking whether package ‘LFApp’ can be installed ... WARNING
    ```
    Found the following significant warnings:
      Warning: The `hairlines` argument of `f7Block()` is deprecated as of shinyMobile 2.0.0.
      Warning: The `multiCollapse` argument of `f7Accordion()` is deprecated as of shinyMobile
    See ‘/Users/davidgranjon/david/RinteRface/shinyMobile/revdep/checks.noindex/LFApp/new/LFApp.Rcheck/00install.out’ for details.
    ```
```